### PR TITLE
Use proper version 1.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {xref_checks, [exports_not_used, undefined_function_calls]}.
 {deps, [
-  {proper, "1.0", {git,"https://github.com/manopapad/proper.git", "master"}}
+  {proper, "1.1", {git,"https://github.com/manopapad/proper.git", {tag, "v1.1"}}}
 ]}.
 
 {ct_use_short_names, true}.


### PR DESCRIPTION
Or maybe locker should use .\* for the proper version and just use proper's master branch?
